### PR TITLE
consume streams

### DIFF
--- a/dbf.js
+++ b/dbf.js
@@ -8,7 +8,8 @@ function reader(filename, encoding) {
   var fileReader = file.reader(filename),
       decode = utf8.test(encoding) ? decodeUtf8 : decoder(encoding || "ISO-8859-1"),
       fieldDescriptors = [],
-      recordBytes;
+      recordBytes,
+      rowCount;
 
   function readHeader(callback) {
     fileReader.read(32, function(error, fileHeader) {
@@ -28,6 +29,7 @@ function reader(filename, encoding) {
           });
           n += 32;
         }
+        rowCount = recordCount;
         callback(null, {
           version: fileType,
           date: fileDate,
@@ -41,7 +43,11 @@ function reader(filename, encoding) {
 
   function readRecord(callback) {
     if (!recordBytes) return callback(new Error("must read header before reading records")), this;
+    if (!rowCount) {
+       return callback(null, end), this;
+    }
     fileReader.read(recordBytes, function readRecord(error, record) {
+      rowCount--;
       if (record === end) return callback(null, end);
       if (error) return void callback(error);
       var i = 1;

--- a/index.js
+++ b/index.js
@@ -25,19 +25,31 @@ function reader(filename, options) {
       encoding = null,
       ignoreProperties = false,
       dbfReader,
-      shpReader;
+      shpReader,
+      dbfStream,
+      shpStream;
 
   if (typeof options === "string") options = {encoding: options};
 
+  if (typeof filename === 'object') options = filename, filename = null;
+
   if (options)
     "encoding" in options && (encoding = options["encoding"]),
-    "ignore-properties" in options && (ignoreProperties = !!options["ignore-properties"]);
+    "ignore-properties" in options && (ignoreProperties = !!options["ignore-properties"]),
+    "dbf" in options && (dbfStream = options.dbf),
+    "shp" in options && (shpStream = options.shp);
 
-  if (/\.shp$/.test(filename)) filename = filename.substring(0, filename.length - 4);
+  if (filename) {
+    if (/\.shp$/.test(filename)) filename = filename.substring(0, filename.length - 4);
 
-  if (!ignoreProperties) dbfReader = dbf.reader(filename + ".dbf", encoding);
-  shpReader = shp.reader(filename + ".shp");
-
+    if (!ignoreProperties) dbfReader = dbf.reader(filename + ".dbf", encoding);
+    shpReader = shp.reader(filename + ".shp");
+  } else {
+    shpReader = shp.reader(shpStream);
+    if (dbfStream) {
+      dbfReader = dbf.reader(dbfStream, encoding);
+    }
+  }
   function readHeader(callback) {
     dbfReader.readHeader(function(error, header) {
       if (header === end) error = new Error("unexpected EOF");

--- a/index.js
+++ b/index.js
@@ -158,7 +158,6 @@ function createReadStream() {
       }
     });
   });
-  return out;
 }
 
 var convertGeometryTypes = {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "main": "./index.js",
   "dependencies": {
     "iconv-lite": "0.2",
+    "noms": "0.0.0",
     "optimist": "0.3",
     "queue-async": "1"
   },

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "vows": "0.7"
   },
   "scripts": {
-    "test": "./node_modules/.bin/vows && echo"
+    "test": "vows --spec"
   },
   "bin": {
     "dbfcat": "./bin/dbfcat",

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -6,23 +6,26 @@ var shapefile = require("../");
 
 var suite = vows.describe("shapefile");
 
-suite.addBatch({
-  "An empty shapefile": testConversion("empty"),
-  "A shapefile with boolean properties": testConversion("boolean-property"),
-  "A shapefile with numeric properties": testConversion("number-property"),
-  "A shapefile with string properties": testConversion("string-property"),
-  "A shapefile with mixed properties": testConversion("mixed-properties"),
-  "A shapefile with date properties": testConversion("date-property"),
-  "A shapefile with UTF-8 property names": testConversion("utf8-property", {encoding: "utf-8"}),
-  "A shapefile with ISO-8859-1 property names": testConversion("latin1-property"),
-  "A shapefile of points": testConversion("points"),
-  "A shapefile of multipoints": testConversion("multipoints"),
-  "A shapefile of polylines": testConversion("polylines"),
-  "A shapefile of polygons": testConversion("polygons"),
-  "A shapefile of null features": testConversion("null"),
-  "ignoring properties": testConversion("ignore-properties", {"ignore-properties": true})
-});
-
+function addAll(testConversion) {
+  suite.addBatch({
+    "An empty shapefile": testConversion("empty"),
+    "A shapefile with boolean properties": testConversion("boolean-property"),
+    "A shapefile with numeric properties": testConversion("number-property"),
+    "A shapefile with string properties": testConversion("string-property"),
+    "A shapefile with mixed properties": testConversion("mixed-properties"),
+    "A shapefile with date properties": testConversion("date-property"),
+    "A shapefile with UTF-8 property names": testConversion("utf8-property", {encoding: "utf-8"}),
+    "A shapefile with ISO-8859-1 property names": testConversion("latin1-property"),
+    "A shapefile of points": testConversion("points"),
+    "A shapefile of multipoints": testConversion("multipoints"),
+    "A shapefile of polylines": testConversion("polylines"),
+    "A shapefile of polygons": testConversion("polygons"),
+    "A shapefile of null features": testConversion("null"),
+    "ignoring properties": testConversion("ignore-properties", {"ignore-properties": true})
+  });
+}
+addAll(testConversion);
+addAll(testConversionStream);
 function fixActualProperties(feature) {
   for (var key in feature.properties) {
     if (feature.properties[key] == null) {
@@ -48,11 +51,45 @@ function testConversion(name, options) {
     }
   };
 }
-
+function testConversion(name, options) {
+  return {
+    topic: readCollection(name, options),
+    "has the expected features": function(actual) {
+      var expected = JSON.parse(fs.readFileSync("./test/" + name + ".json", "utf-8"));
+      actual.features.forEach(fixActualProperties);
+      expected.features.forEach(fixExpectedProperties);
+      assert.deepEqual(actual, expected);
+    }
+  };
+}
+function testConversionStream(name, options) {
+  return {
+    topic: readCollectionStream(name, options),
+    "has the expected features": function(actual) {
+      var expected = JSON.parse(fs.readFileSync("./test/" + name + ".json", "utf-8"));
+      actual.features.forEach(fixActualProperties);
+      expected.features.forEach(fixExpectedProperties);
+      assert.deepEqual(actual, expected);
+    }
+  };
+}
 function readCollection(name, options) {
   return function() {
     shapefile.read("./test/" + name + ".shp", options, this.callback);
   };
 }
-
+function readCollectionStream(name, options) {
+  return function() {
+    options = options || {};
+    var opts = {};
+    Object.keys(options).forEach(function (key) {
+      opts[key] = options[key];
+    });
+    opts.shp = fs.createReadStream("./test/" + name + ".shp");
+    if (!options["ignore-properties"]) {
+      opts.dbf = fs.createReadStream("./test/" + name + ".dbf");
+    }
+    shapefile.read(opts, this.callback);
+  };
+}
 suite.export(module);

--- a/test/shp-test.js
+++ b/test/shp-test.js
@@ -1,5 +1,6 @@
 var vows = require("vows"),
-    assert = require("assert");
+    assert = require("assert"),
+    fs = require('fs');
 
 var shp = require("../shp");
 
@@ -100,6 +101,15 @@ suite.addBatch({
         {shapeType: 1, x: 17, y: 18}
       ]);
     }
+  },
+  "The records of a shapefile of multipoints from a stream": {
+    topic: readRecordsFromStream("./test/multipoints.shp"),
+    "have the expected values": function(records) {
+      assert.deepEqual(records, [
+        {shapeType: 8, box: [1, 2, 9, 10], points: [[1, 2], [3, 4], [5, 6], [7, 8], [9, 10]]},
+        {shapeType: 8, box: [11, 12, 19, 20], points: [[11, 12], [13, 14], [15, 16], [17, 18], [19, 20]]}
+      ]);
+    }
   }
 });
 
@@ -116,6 +126,15 @@ function readRecords(path, encoding) {
   return function() {
     var callback = this.callback;
     shp.read(path, encoding, function(error, header, records) {
+      callback(error, records);
+    });
+  };
+}
+
+function readRecordsFromStream(path, encoding) {
+  return function() {
+    var callback = this.callback;
+    shp.read(fs.createReadStream(path), encoding, function(error, header, records) {
       callback(error, records);
     });
   };


### PR DESCRIPTION
instead of a filename you can pass a `shp` and `dbf` member to the options, these need to be readable streams, in other words instead of 

 ```js
shapefile.reader('./filename.shp');
```

you can do

 ```js
shapefile.reader({
  shp: fs.createReadStream('./filename.shp'),
  dbf: fs.createReadStream('./filename.dbf')
})
```

not really much for files on the hard drive, but *is* helpful when you are getting the files over a network or something similar. 