### PR TITLE
Add license information to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,6 @@
     "dbfcat": "./bin/dbfcat",
     "shpcat": "./bin/shpcat",
     "shp2json": "./bin/shp2json"
-  }
+  },
+  "license": "BSD"
 }


### PR DESCRIPTION
Adds the license information to the `package.json`, so that it becomes visible and searchable in `npm`.