### PR TITLE
Upgrade to iconv-lite 0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test": "./node_modules/.bin/vows && echo"
   },
   "dependencies": {
-    "iconv-lite": "0.2",
+    "iconv-lite": "0.4",
     "optimist": "0.3",
     "d3-queue": "1"
   },


### PR DESCRIPTION
In Japan, Shift JIS encoding is used for DBF file by default.
Latest iconv-lite support Shift JIS encoding , so please consider upgrading iconv-lite dependency from 0.2 to 0.4.