### PR TITLE
Remove deprecated text-encoder

### DIFF
--- a/index.node.js
+++ b/index.node.js
@@ -1,3 +1,1 @@
 'use strict';
-
-var TextDecoder = require("text-encoding").TextDecoder;

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
     "commander": "2",
     "path-source": "0.1",
     "slice-source": "0.4",
-    "stream-source": "0.3",
-    "text-encoding": "^0.6.4"
+    "stream-source": "0.3"
   },
   "devDependencies": {
     "package-preamble": "0.1",


### PR DESCRIPTION
This PR removes the `text-encoding` dependency, which is [no longer maintained](https://www.npmjs.com/package/text-encoding). The change is minimal.

A compliant implementation of TextDecoder has been a Node.js global [since v11](https://nodejs.org/dist/latest-v18.x/docs/api/util.html#new-textdecoderencoding-options) (so all maintained versions of Node have it and this package is redundant for [the default](https://nodejs.org/dist/latest-v18.x/docs/api/util.html#whatwg-supported-encodings) build configuration).

Closes #51 